### PR TITLE
Removed Title Background Change

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,7 +42,7 @@ a {
 }
 
 a:hover {
-  color: #84C2FF;
+  color: #FFF;
 }
 
 ul {

--- a/style.css
+++ b/style.css
@@ -42,8 +42,7 @@ a {
 }
 
 a:hover {
-  background: #84C2FF;
-  color: #FFF;
+  color: #84C2FF;
 }
 
 ul {


### PR DESCRIPTION
There is no longer a blue background when hovering over a link, however, the text does still turn white to make it clear that the mouse is over the link.