### PR TITLE
Increase tap area for hacks button

### DIFF
--- a/src/components/hacks-button.vue
+++ b/src/components/hacks-button.vue
@@ -1,9 +1,7 @@
 <template>
-  <div class="hacks-button">
-    <a class="hacks-button__row" :href="link" target="_blank">
-      <slot />
-    </a>
-  </div>
+  <a class="hacks-button" :href="link" target="_blank">
+    <slot />
+  </a>
 </template>
 
 <script>
@@ -34,20 +32,16 @@ export default {
   padding: 15px;
   transition: background-color 1s;
 
-  &__row {
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-around;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-around;
 
-    > * {
-      margin: 0 5px;
-    }
+  > * {
+    margin: 0 5px;
   }
 
-  a {
-    text-decoration: none;
-    color: black;
-  }
+  text-decoration: none;
+  color: black;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Currently you have to hover over the text/icon in the hacks button to open the link (see the cursor). The button still changes color, but clicking anywhere other than the text/icon doesn't do anything:

![Screenshot 2021-05-31 at 3 15 47 PM](https://user-images.githubusercontent.com/34677361/120155324-44de5f00-c223-11eb-90dd-d4304aeffb29.png)

Now you can click anywhere in the button to open the link (again, see the cursor):

![Screenshot 2021-05-31 at 3 15 52 PM](https://user-images.githubusercontent.com/34677361/120155459-6f301c80-c223-11eb-9b8b-e629a9d77a9c.png)

All I did was remove the `a`'s parent `div`.