### PR TITLE
Remove Ackee

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "ackee-tracker": "^4.1.0",
     "core-js": "^3.6.4",
     "vue": "^2.6.12",
     "vue-router": "^3.4.8"

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,6 @@
 import Vue from 'vue';
 import App from './App.vue';
 import router from './router';
-import * as Ackee from 'ackee-tracker';
 
 Vue.config.productionTip = false;
 
@@ -10,13 +9,3 @@ new Vue({
   render: (h) => h(App),
   mounted: () => document.dispatchEvent(new Event("x-app-rendered")),
 }).$mount('#app');
-
-if (typeof window !== 'undefined') {
-  Ackee.create({
-    server: 'https://ackee.nuhacks.io',
-    domainId: 'd7ef3906-37ed-4496-81d1-8c6a22e58231'
-  }, {
-    ignoreLocalhost: true,
-    detailed: false
-  }).record();
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1579,13 +1579,6 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
-ackee-tracker@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ackee-tracker/-/ackee-tracker-4.1.0.tgz#775ba71164df84e83adfff88c0a08fd1be1768a6"
-  integrity sha512-0WVWU0acUf03s+1tUtjpUt1/dawI/0vetdH3eWfxKmuLlYPnnHbZrRgFBg2Aj26TpLUGnWbgnkerc0Yq/w7LJw==
-  dependencies:
-    platform "^1.3.6"
-
 acorn-jsx@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -6496,11 +6489,6 @@ pkg-dir@^4.1.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-platform@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
-  integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
 pnp-webpack-plugin@^1.6.4:
   version "1.6.4"


### PR DESCRIPTION
Removes Ackee.

## Background

Ackee is a privacy-respecting web analytics service, i.e. open-source self-hosted Google Analytics.
I was self-hosting it but I'm decommissioning the server since nobody has been checking Ackee and also I've graduated.

If the current Hacks webmaster/eboard is interested in privacy-respecting website usage tracking, I can help you figure it out. Otherwise, just use Google.